### PR TITLE
Adds min package version

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -5,12 +5,6 @@ on:
   schedule:
     - cron: '45 3 * * 0'
   workflow_dispatch:
-  # Section to be removed before action is merged
-  #  note: branch below needs to point to main instead of new-verdepcheck-strategy
-  push:
-    branches:
-      - verdepcheck_action
-  # end of section to be removed
 
 jobs:
   dependency-test:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -5,13 +5,19 @@ on:
   schedule:
     - cron: '45 3 * * 0'
   workflow_dispatch:
+  # Section to be removed before action is merged
+  #  note: branch below needs to point to main instead of new-verdepcheck-strategy
+  push:
+    branches:
+      - verdepcheck_action
+  # end of section to be removed
 
 jobs:
   dependency-test:
     strategy:
       fail-fast: false
       matrix:
-        test-strategy: ["min", "release", "max"]
+        test-strategy: ["min_cohort", "min_isolated", "release", "max"]
     uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@main
     name: Dependency Test - ${{ matrix.test-strategy }} 🔢
     secrets:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,26 +14,38 @@ URL: https://github.com/insightsengineering/tern.rbmi,
 BugReports: https://github.com/insightsengineering/tern.rbmi/issues
 Depends:
     R (>= 3.6),
-    rbmi,
+    rbmi (>= 1.1.4),
     tern (>= 0.7.10)
 Imports:
-    broom,
-    checkmate,
+    broom (>= 0.5.4),
+    checkmate (>= 2.1.0),
     formatters (>= 0.3.1),
-    lifecycle,
-    magrittr,
+    lifecycle (>= 0.2.0),
+    magrittr (>= 1.5),
     rtables (>= 0.5.1)
 Suggests:
-    dplyr,
-    knitr,
+    dplyr (>= 1.0.3),
+    knitr (>= 1.42),
     Matrix,
-    rmarkdown,
-    testthat (>= 2.0),
-    tidyr
+    testthat (>= 3.0.4),
+    tidyr (>= 0.8.3)
 VignetteBuilder:
     knitr
 Remotes:
     insightsengineering/tern@*release
+Config/Needs/verdepcheck:
+    insightsengineering/rbmi,
+    insightsengineering/tern,
+    tidymodels/broom,
+    mllg/checkmate,
+    insightsengineering/formatters,
+    r-lib/lifecycle,
+    tidyverse/magrittr,
+    insightsengineering/rtables,
+    tidyverse/dplyr,
+    yihui/knitr,
+    r-lib/testthat,
+    tidyverse/tidyr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ URL: https://github.com/insightsengineering/tern.rbmi,
 BugReports: https://github.com/insightsengineering/tern.rbmi/issues
 Depends:
     R (>= 3.6),
-    rbmi (>= 1.2.0),
+    rbmi (>= 1.2.3),
     tern (>= 0.7.10)
 Imports:
     broom (>= 0.5.4),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ URL: https://github.com/insightsengineering/tern.rbmi,
 BugReports: https://github.com/insightsengineering/tern.rbmi/issues
 Depends:
     R (>= 3.6),
-    rbmi (>= 1.2.3),
+    rbmi (>= 1.2.5),
     tern (>= 0.7.10)
 Imports:
     broom (>= 0.5.4),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
     dplyr (>= 1.0.3),
     knitr (>= 1.42),
     Matrix,
+    rmarkdown (>= 2.19),
     testthat (>= 3.0.4),
     tidyr (>= 0.8.3)
 VignetteBuilder:
@@ -44,6 +45,7 @@ Config/Needs/verdepcheck:
     insightsengineering/rtables,
     tidyverse/dplyr,
     yihui/knitr,
+    rstudio/rmarkdown,
     r-lib/testthat,
     tidyverse/tidyr
 Config/Needs/website: insightsengineering/nesttemplate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ URL: https://github.com/insightsengineering/tern.rbmi,
 BugReports: https://github.com/insightsengineering/tern.rbmi/issues
 Depends:
     R (>= 3.6),
-    rbmi (>= 1.1.4),
+    rbmi (>= 1.2.0),
     tern (>= 0.7.10)
 Imports:
     broom (>= 0.5.4),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # `tern.rbmi` 0.1.2.9008
 
+* Specified minimal version of package dependencies.
+* Corrects tidy.pool function signature
+
 # `tern.rbmi` 0.1.2
 
 * Add more tests and examples, coverage is at 100%!

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # `tern.rbmi` 0.1.2.9008
 
 * Specified minimal version of package dependencies.
-* Corrects tidy.pool function signature
+* Corrected tidy.pool function signature
 
 # `tern.rbmi` 0.1.2
 

--- a/R/tabulate_rbmi.R
+++ b/R/tabulate_rbmi.R
@@ -64,10 +64,11 @@ h_tidy_pool <- function(x) {
 #' @method tidy pool
 #' @param x (`pool`) is a list of pooled object from `rbmi` analysis results. This list includes
 #' analysis results, confidence level, hypothesis testing type.
+#' @param ... Additional arguments. Not used. Needed to match generic signature only.
 #' @export
 #' @return A dataframe
 #'
-tidy.pool <- function(x) { # nolint
+tidy.pool <- function(x, ...) { # nolint
 
   ls_raw <- x$pars
 

--- a/man/tidy.pool.Rd
+++ b/man/tidy.pool.Rd
@@ -5,11 +5,13 @@
 \title{Helper method (for \code{\link[broom:reexports]{broom::tidy()}}) to prepare a data frame from an
 \code{pool} \code{rbmi} object containing the LS means and contrasts and multiple visits}
 \usage{
-\method{tidy}{pool}(x)
+\method{tidy}{pool}(x, ...)
 }
 \arguments{
 \item{x}{(\code{pool}) is a list of pooled object from \code{rbmi} analysis results. This list includes
 analysis results, confidence level, hypothesis testing type.}
+
+\item{...}{Additional arguments. Not used. Needed to match generic signature only.}
 }
 \value{
 A dataframe


### PR DESCRIPTION
WIP :: parent issue: https://github.com/insightsengineering/nestdevs-tasks/issues/7

### 🔴 Checklist for PR Reviewer

[![Scheduled 🕰️](https://github.com/insightsengineering/tern.rbmi/actions/workflows/scheduled.yaml/badge.svg?branch=verdepcheck_action)](https://github.com/insightsengineering/tern.rbmi/actions/workflows/scheduled.yaml?query=branch%3Averdepcheck_action)

- [x] Tag yourself next to this repo on https://github.com/insightsengineering/nestdevs-tasks/issues/7
- [x] Package versions are the same or higher than `main`
- [x] Package list is the same
  - Only exception is `rmarkdown` (may have been removed on `Suggests`)
- [x] All packages in `Imports`, `Depends` & `Suggests` are in new section `Config/Needs/verdepcheck`
- [x] Added entry to `NEWS.md`
- [x] Last `scheduled.yaml` action was run succesfully _(all 4 strategies)_
  - important: it's not the last commit, it's the one that runs 4 `Scheduled 🕰️ / Dependency` actions
- [x] `scheduled.yaml` SHOULD NOT have any push on any branches

### 🔴 What's needed before merging?

This PR depends on some upstream changes that need to be finalized/merged before being ready to review.

#### Change in code

* `verdepcheck.yml` action (see comments)
  - [x] Remove `on: push` section 
  - [x] Change branch to main

#### PRS

- [x] verdepcheck
  * https://github.com/insightsengineering/verdepcheck/pull/24
  * https://github.com/insightsengineering/verdepcheck/pull/26
- [x] verdepcheck-action
  * https://github.com/insightsengineering/r-verdepcheck-action/pull/16

### Changes description

* Adds minimum version for packages `DESCRIPTION`
* Adds `Config/Need/verdepcheck` section in `DESCRIPTION`
* Updates verdepcheck action