### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Suggests:
     dplyr (>= 1.0.3),
     knitr (>= 1.42),
     Matrix,
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     testthat (>= 3.0.4),
     tidyr (>= 0.8.3)
 VignetteBuilder:


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.